### PR TITLE
100 instead of 1000 on the exception raised when the price is below 100.

### DIFF
--- a/src/Invoice/InvoiceItem.php
+++ b/src/Invoice/InvoiceItem.php
@@ -59,7 +59,7 @@ class InvoiceItem
         }
         else 
         {
-            throw new Exception('Price must be a number and greather than 1000 !');
+            throw new Exception('Price must be a number and greather than 100 !');
         }
     }
 


### PR DESCRIPTION
j'ai vue qu'au niveau du message sur l'exception levée quand le prix entrer par l'utilisateur est inférieure à 100, vous avez mis : "Price must be a number and greather than 1000 !".        
je crois que ça devrait être 100 au lieu de 1000.